### PR TITLE
Add some basic testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,27 @@
+name: test
+on: [ push, pull_request ]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        emacs_version:
+        - 25.1
+        - 25.3
+        - 26.1
+        - 26.2
+        - 26.3
+        - 27.1
+        - 27.2
+        - snapshot
+    steps:
+    - name: Install emacs
+      uses: purcell/setup-emacs@master
+      with:
+        version: ${{ matrix.emacs_version }}
+    - name: Checkout
+      uses: actions/checkout@v3
+      with:
+        path: .
+    - name: Test
+      run: make test

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 *.elc
+test/RPMS/*
+test/RPMS

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,29 @@
+.PHONY: rpms rpm-source rpm-clean rpm-zstd rpm-gz rpm-xz \
+	test test-interactive
+
+rpms: rpm-clean rpm-source rpm-zstd rpm-gz rpm-xz
+
+rpm-clean:
+	rm -rf ~/rpmbuild/SOURCES/* test/RPMS
+
+rpm-source:
+	mkdir -p ~/rpmbuild/SOURCES test/RPMS
+	tar -C test -cvzf ~/rpmbuild/SOURCES/package-1.tgz package-1
+
+rpm-zstd:
+	rpmbuild -ba test/package.spec --define "_binary_payload w19.zstdio"
+	mv ~/rpmbuild/RPMS/noarch test/RPMS/zstd
+
+rpm-gz:
+	rpmbuild -ba test/package.spec --define "_binary_payload w9.gzdio"
+	mv ~/rpmbuild/RPMS/noarch test/RPMS/gz
+
+rpm-xz:
+	rpmbuild -ba test/package.spec --define "_binary_payload w6.xzdio"
+	mv ~/rpmbuild/RPMS/noarch test/RPMS/xz
+
+test: rpms
+	make -C test test
+
+test-interactive: rpms
+	make -C test test-interactive

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+![Tests](https://github.com/nbarrientos/archive-rpm/actions/workflows/test.yml/badge.svg)
+
 # archive-rpm
 Browse RPM and CPIO archives in Emacs with archive-mode
 
@@ -19,3 +21,6 @@ To install these modules, type `M-x package-install-file`, and select
 the _directory_ containing `archive-rpm.el` and `archive-cpio.el`
 (don't select one of the modules themselves!).  After that, any RPM
 files you open should display as some metadata plus a file listing.
+
+To run the test suite make sure that `rpmbuild` is installed on the
+system and run `make test`.

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,0 +1,9 @@
+test:
+	emacs -Q --batch -L .. --eval "(progn\
+	(load-file \"archive-rpm-tests.el\")\
+	(ert-run-tests-batch-and-exit))"
+
+test-interactive:
+	emacs -Q -L .. --eval "(progn\
+	(load-file \"archive-rpm-tests.el\")\
+	(ert t))"

--- a/test/archive-rpm-tests.el
+++ b/test/archive-rpm-tests.el
@@ -1,0 +1,102 @@
+;;; archive-rpm-tests.el --- Tests for archive-rpm   -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2022  Nacho Barrientos
+
+;; Author: Nacho Barrientos <nacho.barrientos@cern.ch>
+;; URL: https://github.com/nbarrientos/archive-rpm
+;; Package-Requires: ((emacs "24.1"))
+;; Package-Version: 0.1
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; These are tests for archive-rpm.el
+
+;;; Code:
+
+(require 'ert)
+
+(require 'archive-rpm)
+
+(defun archive-rpm-tests--find-regexp-in-buffer (regexp)
+  (save-excursion
+    (goto-char (point-min))
+    (search-forward-regexp
+     regexp
+     nil
+     t)))
+
+(defun archive-rpm-tests--find-field-in-buffer (field value)
+  (archive-rpm-tests--find-regexp-in-buffer (format "^%s:[ ]*%s$" field value)))
+
+(defmacro archive-rpm-tests--with-rpm (rpm &rest body)
+  `(let ((buffer (find-file-noselect ,rpm)))
+     (with-current-buffer buffer
+       ,@body)))
+
+(ert-deftest archive-rpm-tests--expected-buffer-mode ()
+  "Test that the buffer has archive-mode enabled."
+  (archive-rpm-tests--with-rpm
+   "RPMS/gz/package-1-1.noarch.rpm"
+   (should (equal 'archive-mode major-mode))))
+
+(ert-deftest archive-rpm-tests--expected-buffer-size ()
+  "Test that the buffer contains all the expected lines."
+  (archive-rpm-tests--with-rpm
+   "RPMS/gz/package-1-1.noarch.rpm"
+   (should (equal 15 (count-lines (point-min) (point-max))))))
+
+(ert-deftest archive-rpm-tests--expected-number-of-files ()
+  "Test that the number of files listed is correct."
+  (archive-rpm-tests--with-rpm
+   "RPMS/gz/package-1-1.noarch.rpm"
+   (should (equal 2 (count-lines archive-file-list-start (point-max))))))
+
+(ert-deftest archive-rpm-tests--expected-fields ()
+  "Test that all the fields that are RPM metadata are correctly displayed."
+  (archive-rpm-tests--with-rpm
+   "RPMS/gz/package-1-1.noarch.rpm"
+   (should (not (null (archive-rpm-tests--find-field-in-buffer "Name" "package"))))
+   (should (not (null (archive-rpm-tests--find-field-in-buffer "Version" "1"))))
+   (should (not (null (archive-rpm-tests--find-field-in-buffer "Release" "1"))))
+   (should (not (null (archive-rpm-tests--find-field-in-buffer "Architecture" "noarch"))))
+   (should (not (null (archive-rpm-tests--find-field-in-buffer "Format" "cpio"))))
+   (should (not (null (archive-rpm-tests--find-field-in-buffer "Vendor" "ACME Inc\\."))))
+   (should (not (null (archive-rpm-tests--find-field-in-buffer "URL" "https://example\\.org"))))
+   (should (not (null (archive-rpm-tests--find-field-in-buffer "License" "BSD"))))))
+
+(ert-deftest archive-rpm-tests--expected-compression-gzip ()
+  "Test that RPMs compressed using gzip can be visited."
+  (archive-rpm-tests--with-rpm
+   "RPMS/gz/package-1-1.noarch.rpm"
+   (should (not (null (archive-rpm-tests--find-field-in-buffer "Compression" "gzip"))))
+   (should (not (null (archive-rpm-tests--find-regexp-in-buffer "\\./usr/share/doc/package-1/README\\.md$"))))))
+
+(ert-deftest archive-rpm-tests--expected-compression-xz ()
+  "Test that RPMs compressed using xz can be visited."
+  (archive-rpm-tests--with-rpm
+   "RPMS/xz/package-1-1.noarch.rpm"
+   (should (not (null (archive-rpm-tests--find-field-in-buffer "Compression" "xz"))))
+   (should (not (null (archive-rpm-tests--find-regexp-in-buffer "\\./usr/share/doc/package-1/README\\.md$"))))))
+
+(ert-deftest archive-rpm-tests--expected-compression-zstd ()
+  "Test that RPMs compressed using zstd can be visited."
+  (archive-rpm-tests--with-rpm
+   "RPMS/zstd/package-1-1.noarch.rpm"
+   (should (not (null (archive-rpm-tests--find-field-in-buffer "Compression" "zstd"))))
+   (should (not (null (archive-rpm-tests--find-regexp-in-buffer "\\./usr/share/doc/package-1/README\\.md$"))))))
+
+(provide 'archive-rpm-tests)
+;;; archive-rpm-tests.el ends here

--- a/test/package-1/README.md
+++ b/test/package-1/README.md
@@ -1,0 +1,1 @@
+This is a test

--- a/test/package.spec
+++ b/test/package.spec
@@ -1,0 +1,24 @@
+Name: package
+Version: 1
+Release: 1%{?dist}
+Summary: Test RPM
+License: BSD
+BuildArch: noarch
+Source: %{name}-%{version}.tgz
+URL: https://example.org
+Vendor: ACME Inc.
+
+%description
+RPM for testing
+
+%prep
+%setup -n %{name}-%{version}
+
+%build
+rm -rf %{buildroot}
+
+%install
+
+%files
+%defattr(-,root,root,-)
+%doc README.md


### PR DESCRIPTION
This patch adds:

* Makefile rules to create a test environment and to run the test suite, both in batch and interactively.
* Dummy RPMs to test different types of compression algorithms.
* Some ERT tests.
* A test matrix to test the package against different versions of Emacs (ranging from 25 to snapshot)

I'm creating this MR here as well in view of https://github.com/legoscia/archive-rpm/pull/4 not being merged and https://github.com/melpa/melpa/pull/7945 going forward.