### PR TITLE
Make sure that the lib byte-compiles with no warnings/errors

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,5 +24,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         path: .
+    - name: Byte Compile
+      run: make byte-compile
     - name: Test
       run: make test

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: rpms rpm-source rpm-clean rpm-zstd rpm-gz rpm-xz \
-	test test-interactive
+	test test-interactive byte-compile
 
 rpms: rpm-clean rpm-source rpm-zstd rpm-gz rpm-xz
 
@@ -27,3 +27,6 @@ test: rpms
 
 test-interactive: rpms
 	make -C test test-interactive
+
+byte-compile:
+	make -C test byte-compile

--- a/archive-cpio.el
+++ b/archive-cpio.el
@@ -31,6 +31,9 @@
 
 ;;; Code:
 
+(require 'arc-mode)
+(require 'cl-lib)
+
 (defconst archive-cpio-entry-header-re
   "07070[12]\\([[:xdigit:]]\\{8\\}\\)\\([[:xdigit:]]\\{8\\}\\)\\([[:xdigit:]]\\{8\\}\\)\\([[:xdigit:]]\\{8\\}\\)\\([[:xdigit:]]\\{8\\}\\)\\([[:xdigit:]]\\{8\\}\\)\\([[:xdigit:]]\\{8\\}\\)\\([[:xdigit:]]\\{8\\}\\)\\([[:xdigit:]]\\{8\\}\\)\\([[:xdigit:]]\\{8\\}\\)\\([[:xdigit:]]\\{8\\}\\)\\([[:xdigit:]]\\{8\\}\\)[[:xdigit:]]\\{8\\}\\|\0+\\'"
   "Regular expression matching a CPIO entry.

--- a/archive-rpm.el
+++ b/archive-rpm.el
@@ -32,6 +32,7 @@
 
 (require 'archive-cpio)
 (require 'bindat)
+(require 'cl-lib)
 
 ;;;###autoload
 (defun archive-rpm-find-type ()

--- a/test/Makefile
+++ b/test/Makefile
@@ -7,3 +7,7 @@ test-interactive:
 	emacs -Q -L .. --eval "(progn\
 	(load-file \"archive-rpm-tests.el\")\
 	(ert t))"
+
+byte-compile:
+	emacs -Q --batch -L .. -l archive-rpm-byte-compile.el 2>&1 \
+	| grep -E "([Ee]rror|[Ww]arning):" && exit 1 || exit 0

--- a/test/archive-rpm-byte-compile.el
+++ b/test/archive-rpm-byte-compile.el
@@ -1,0 +1,51 @@
+(require 'find-lisp)
+
+;; The byte-compiler throws warnings on <28 because the structs
+;; declared below do not exist. Define them to mask the "false
+;; positive".
+(when (< emacs-major-version 28)
+  (cl-defstruct (archive--file-summary
+                 (:constructor nil)
+                 (:constructor archive--file-summary (text name-start name-end)))
+    text name-start name-end)
+
+  (cl-defstruct (archive--file-desc
+                 (:constructor nil)
+                 (:constructor archive--file-desc
+                               ;; ext-file-name and int-file-name are usually `eq'
+                               ;; except when int-file-name is the downcased
+                               ;; ext-file-name.
+                               (ext-file-name int-file-name mode size time
+                               &key pos ratio uid gid)))
+    ext-file-name int-file-name
+    (mode nil  :type integer)
+    (size nil  :type integer)
+    (time nil  :type string)
+    (ratio nil :type string)
+    uid gid
+    pos))
+
+;; We skip 26 and older due to a warning when using
+;; `string-to-unibyte'. In 26 the byte compiler throws a deprecation
+;; warning however 27 onwards reverted this.
+;; From NEWS.27:
+;;   ** The functions 'string-to-unibyte' and 'string-to-multibyte' are no
+;;   longer declared obsolete.  We have found that there are legitimate use
+;;   cases for these functions, where there's no better alternative.  We
+;;   believe that the incorrect uses of these functions all but disappeared
+;;   by now, so we are un-obsoleting them.
+(when (>= emacs-major-version 27)
+  (let ((files (find-lisp-find-files-internal
+                ".."
+                (lambda (file dir)
+                  (and (not (file-directory-p (expand-file-name file dir)))
+                       (not (string-match "pkg\\.el$" file))
+                       (string-match "\\.el$" file)
+                       (not (string-match "\\.dir-locals\\.el" file))))
+                (lambda (dir parent)
+                  (not (or (string= dir ".")
+                           (string= dir "..")
+                           (string= dir ".git")
+                           (string= dir "test")))))))
+    (dolist (file files)
+      (byte-compile-file file))))


### PR DESCRIPTION
This patchset adds a new test to byte-compile all the components of the library. If there are warnings or errors the CI job fails.

It has a caveat, though.

``` emacs-lisp
              (if (< emacs-major-version 28)
                  (progn
                    (push (vector text (length text-a) (length text)) visual)
                    (push (vector name name nil mode filebeg) files))
                (push (archive--file-summary text (length text-a) (length text)) visual)
                (push (archive--file-desc name name mode filesize nil :pos filebeg) files))
```

Will emit warnings in Emacs < 28 as the byte compiler is not smart enough to realise that `archive--file-desc` and `archive--file-desc` are not going to be called (and they're Emacs 28 only). To workaround this issue the test declares the structs to mask the warnings when necessary.

Older versions than 27 are skipped due to `string-to-unibyte` being declared as deprecated in 26 and re-accepted in 27.